### PR TITLE
🐛 fix: guide unexpected errors to issue tracker

### DIFF
--- a/src/gh_llm/cli.py
+++ b/src/gh_llm/cli.py
@@ -29,25 +29,18 @@ def run(argv: list[str]) -> int:
         print(f"error: {error}", file=sys.stderr)
         return 1
     except Exception as error:  # pragma: no cover - covered by explicit CLI test
+        command = shlex.join([detect_prog_name(sys.argv[0]), *argv])
         print(f"unexpected error: {error}", file=sys.stderr)
         print(file=sys.stderr)
         print("This looks like an unexpected gh-llm failure.", file=sys.stderr)
+        print("⌨ issue_title: '<short summary>'", file=sys.stderr)
+        print("⌨ issue_body: '<what happened, expected result, actual result>'", file=sys.stderr)
         print(
-            "Please file an issue via gh:",
+            "⏎ Create issue via gh: `gh issue create --repo ShigureLab/gh-llm --title '<short summary>' --body '<what happened, expected result, actual result>'`",
             file=sys.stderr,
         )
-        print(
-            "gh issue create --repo ShigureLab/gh-llm --web",
-            file=sys.stderr,
-        )
-        print(
-            "If useful, include the command that triggered it:",
-            file=sys.stderr,
-        )
-        print(
-            shlex.join([detect_prog_name(sys.argv[0]), *argv]),
-            file=sys.stderr,
-        )
+        print("If useful, include the command that triggered it:", file=sys.stderr)
+        print(command, file=sys.stderr)
         return 1
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1036,7 +1036,12 @@ def test_cli_unexpected_error_shows_issue_guidance(
     err = capsys.readouterr().err
     assert "unexpected error: 'boom'" in err
     assert "This looks like an unexpected gh-llm failure." in err
-    assert "gh issue create --repo ShigureLab/gh-llm --web" in err
+    assert "⌨ issue_title: '<short summary>'" in err
+    assert "⌨ issue_body: '<what happened, expected result, actual result>'" in err
+    assert (
+        "⏎ Create issue via gh: `gh issue create --repo ShigureLab/gh-llm --title '<short summary>' --body '<what happened, expected result, actual result>'`"
+        in err
+    )
     assert "If useful, include the command that triggered it:" in err
     assert "gh-llm" in err
 


### PR DESCRIPTION
## Summary
- add explicit issue-reporting guidance for unexpected gh-llm failures
- keep expected `RuntimeError` / `ValueError` handling unchanged
- include a `gh issue create --repo ShigureLab/gh-llm --web` command in the unexpected-error path

## Testing
- `uv run pytest`
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyright src/gh_llm tests`
