### PR TITLE
:recycle: refactor: adopt PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ requires-python = ">=3.14"
 dependencies = []
 authors = [{ name = "Nyakku Shigure", email = "sigure.qaq@gmail.com" }]
 keywords = ["github", "cli", "llm", "code-review", "pull-requests", "issues"]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
   "Environment :: Console",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: MIT License",
   "Typing :: Typed",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
## 改动动机
- 当前项目已经在 `[project]` 中声明许可证，但仍保留旧的 `License :: OSI Approved :: MIT License` classifier。
- PEP 639 已将许可证元数据标准化为 SPDX license expression，继续保留旧 classifier 的必要性较低，且不如标准字段明确。

## PEP 639 说明
- 将 `project.license` 从旧的 table 形式迁移为 SPDX 字符串：`MIT`。
- 显式补充 `project.license-files = ["LICENSE"]`，让构建产物携带标准化的许可证文件元数据。
- 移除旧的 license classifier，避免继续依赖已被 PEP 639 取代的许可证声明方式。
- 参考：PEP 639 https://peps.python.org/pep-0639/

## 验证结果
- 已执行：`uv build --out-dir <tmp>`
- 构建产物元数据包含：`License-Expression: MIT`
- 构建产物元数据包含：`License-File: LICENSE`
- 不再包含旧的 `License :: OSI Approved :: MIT License` classifier
