### PR TITLE
🐛 fix: streamline rendered action hints

### DIFF
--- a/skills/github-conversation/SKILL.md
+++ b/skills/github-conversation/SKILL.md
@@ -29,8 +29,9 @@ GitHub stores the body text exactly as sent.
 1. Do not write multi-paragraph bodies as literal escape sequences such as `\n` or `\n\n`.
 2. If you send `--body 'line1\n\nline2'`, GitHub may store the backslashes literally, and the rendered review/comment will show `\n\n`.
 3. Use `--body` only for short single-paragraph text.
-4. For quotes, bullets, code fences, or multiple paragraphs, prefer `--body-file` with a file or `-` on standard input.
-5. For review suggestions that span multiple lines, prefer `--suggestion-file`.
+4. In the command patterns documented by this skill, every write action that accepts `--body` also has a `--body-file` form.
+5. For quotes, bullets, code fences, or multiple paragraphs, prefer `--body-file` with a file or `-` on standard input.
+6. For review suggestions that span multiple lines, prefer `--suggestion-file`.
 
 Safe patterns:
 

--- a/src/gh_llm/github_api.py
+++ b/src/gh_llm/github_api.py
@@ -3157,6 +3157,7 @@ def _render_review_comment_block(
             f"pr comment-edit {comment_id} --body '<comment_body>' --pr {ref.number} --repo {ref.owner}/{ref.name}"
         )
         lines.append(f"  ◌ comment_id: {comment_id}")
+        lines.append("  ⌨ comment_body: '<comment_body>'")
         lines.append(f"  ⏎ Edit comment via {display_command()}: `{edit_cmd}`")
 
     if not body and not diff_hunk:

--- a/src/gh_llm/github_api.py
+++ b/src/gh_llm/github_api.py
@@ -2989,6 +2989,7 @@ def _render_review_thread_block(
     )
     resolve_cmd = display_command_with(f"pr thread-resolve {thread_id} --pr {ref.number} --repo {ref.owner}/{ref.name}")
     lines.append(f"  ◌ thread_id: {thread_id}")
+    lines.append("  ⌨ reply_body: '<reply>'")
     lines.append(f"  ⏎ Reply via {display_command()}: `{reply_cmd}`")
     if is_resolved:
         lines.append(f"  ⏎ Unresolve via {display_command()}: `{unresolve_cmd}`")

--- a/src/gh_llm/github_api.py
+++ b/src/gh_llm/github_api.py
@@ -2989,13 +2989,7 @@ def _render_review_thread_block(
     )
     resolve_cmd = display_command_with(f"pr thread-resolve {thread_id} --pr {ref.number} --repo {ref.owner}/{ref.name}")
     lines.append(f"  ◌ thread_id: {thread_id}")
-    lines.append("  ⌨ reply_body: '<reply>'")
-    lines.append("  ⌨ reply_body_file: '<reply.md>'")
     lines.append(f"  ⏎ Reply via {display_command()}: `{reply_cmd}`")
-    lines.append(
-        "  ⏎ Multi-line reply via "
-        + f"{display_command()}: `{display_command_with(f'pr thread-reply {thread_id} --body-file <reply.md> --pr {ref.number} --repo {ref.owner}/{ref.name}')}`"
-    )
     if is_resolved:
         lines.append(f"  ⏎ Unresolve via {display_command()}: `{unresolve_cmd}`")
     else:
@@ -3161,14 +3155,8 @@ def _render_review_comment_block(
         edit_cmd = display_command_with(
             f"pr comment-edit {comment_id} --body '<comment_body>' --pr {ref.number} --repo {ref.owner}/{ref.name}"
         )
-        edit_file_cmd = display_command_with(
-            f"pr comment-edit {comment_id} --body-file <comment.md> --pr {ref.number} --repo {ref.owner}/{ref.name}"
-        )
         lines.append(f"  ◌ comment_id: {comment_id}")
-        lines.append("  ⌨ comment_body: '<comment_body>'")
-        lines.append("  ⌨ comment_body_file: '<comment.md>'")
         lines.append(f"  ⏎ Edit comment via {display_command()}: `{edit_cmd}`")
-        lines.append(f"  ⏎ Multi-line edit via {display_command()}: `{edit_file_cmd}`")
 
     if not body and not diff_hunk:
         lines.append("  (empty review comment)")

--- a/src/gh_llm/render.py
+++ b/src/gh_llm/render.py
@@ -159,17 +159,11 @@ def render_pr_actions(context: TimelineContext, *, include_diff: bool = True, in
 
         lines.extend(
             [
-                "⌨ comment_body: '<comment_body>'",
                 f"⏎ Comment via gh: `gh pr comment {context.number} --repo {repo} --body '<comment_body>'`",
-                "⌨ comment_body_file: '<path-or->'",
-                f"⏎ Multi-line comment via gh: `gh pr comment {context.number} --repo {repo} --body-file <path-or->`",
                 *close_or_reopen_lines,
-                "⌨ labels_csv: '<label1>,<label2>'",
                 f"⏎ Add labels via gh: `gh pr edit {context.number} --repo {repo} --add-label '<label1>,<label2>'`",
                 f"⏎ Remove labels via gh: `gh pr edit {context.number} --repo {repo} --remove-label '<label1>,<label2>'`",
-                "⌨ reviewers_csv: '<reviewer1>,<reviewer2>'",
                 f"⏎ Request review via gh: `gh pr edit {context.number} --repo {repo} --add-reviewer '<reviewer1>,<reviewer2>'`",
-                "⌨ assignees_csv: '<assignee1>,<assignee2>'",
                 f"⏎ Assign via gh: `gh pr edit {context.number} --repo {repo} --add-assignee '<assignee1>,<assignee2>'`",
                 *branch_lines,
             ]
@@ -186,15 +180,10 @@ def render_issue_actions(context: TimelineContext) -> list[str]:
         close_or_reopen_lines.append(f"⏎ Reopen issue via gh: `gh issue reopen {context.number} --repo {repo}`")
     return [
         "## Actions",
-        "⌨ comment_body: '<comment_body>'",
         f"⏎ Comment via gh: `gh issue comment {context.number} --repo {repo} --body '<comment_body>'`",
-        "⌨ comment_body_file: '<path-or->'",
-        f"⏎ Multi-line comment via gh: `gh issue comment {context.number} --repo {repo} --body-file <path-or->`",
         *close_or_reopen_lines,
-        "⌨ labels_csv: '<label1>,<label2>'",
         f"⏎ Add labels via gh: `gh issue edit {context.number} --repo {repo} --add-label '<label1>,<label2>'`",
         f"⏎ Remove labels via gh: `gh issue edit {context.number} --repo {repo} --remove-label '<label1>,<label2>'`",
-        "⌨ assignees_csv: '<assignee1>,<assignee2>'",
         f"⏎ Assign via gh: `gh issue edit {context.number} --repo {repo} --add-assignee '<assignee1>,<assignee2>'`",
     ]
 
@@ -424,14 +413,8 @@ def _render_item(index: int, event: TimelineEvent, context: TimelineContext, com
             edit_cmd = display_command_with(
                 f"{command_group} comment-edit {event.editable_comment_id} --body '<comment_body>' --{selector_name} {context.number} --repo {context.owner}/{context.name}"
             )
-            edit_file_cmd = display_command_with(
-                f"{command_group} comment-edit {event.editable_comment_id} --body-file <comment.md> --{selector_name} {context.number} --repo {context.owner}/{context.name}"
-            )
             lines.append(f"   ◌ comment_id: {event.editable_comment_id}")
-            lines.append("   ⌨ comment_body: '<comment_body>'")
-            lines.append("   ⌨ comment_body_file: '<comment.md>'")
             lines.append(f"   ⏎ Edit comment via {display_command()}: `{edit_cmd}`")
-            lines.append(f"   ⏎ Multi-line edit via {display_command()}: `{edit_file_cmd}`")
     else:
         lines.extend(_indent_block(display_summary))
     if event.resolved_hidden_count > 0:

--- a/src/gh_llm/render.py
+++ b/src/gh_llm/render.py
@@ -414,6 +414,7 @@ def _render_item(index: int, event: TimelineEvent, context: TimelineContext, com
                 f"{command_group} comment-edit {event.editable_comment_id} --body '<comment_body>' --{selector_name} {context.number} --repo {context.owner}/{context.name}"
             )
             lines.append(f"   ◌ comment_id: {event.editable_comment_id}")
+            lines.append("   ⌨ comment_body: '<comment_body>'")
             lines.append(f"   ⏎ Edit comment via {display_command()}: `{edit_cmd}`")
     else:
         lines.extend(_indent_block(display_summary))

--- a/src/gh_llm/render.py
+++ b/src/gh_llm/render.py
@@ -159,11 +159,15 @@ def render_pr_actions(context: TimelineContext, *, include_diff: bool = True, in
 
         lines.extend(
             [
+                "⌨ comment_body: '<comment_body>'",
                 f"⏎ Comment via gh: `gh pr comment {context.number} --repo {repo} --body '<comment_body>'`",
                 *close_or_reopen_lines,
+                "⌨ labels_csv: '<label1>,<label2>'",
                 f"⏎ Add labels via gh: `gh pr edit {context.number} --repo {repo} --add-label '<label1>,<label2>'`",
                 f"⏎ Remove labels via gh: `gh pr edit {context.number} --repo {repo} --remove-label '<label1>,<label2>'`",
+                "⌨ reviewers_csv: '<reviewer1>,<reviewer2>'",
                 f"⏎ Request review via gh: `gh pr edit {context.number} --repo {repo} --add-reviewer '<reviewer1>,<reviewer2>'`",
+                "⌨ assignees_csv: '<assignee1>,<assignee2>'",
                 f"⏎ Assign via gh: `gh pr edit {context.number} --repo {repo} --add-assignee '<assignee1>,<assignee2>'`",
                 *branch_lines,
             ]
@@ -180,10 +184,13 @@ def render_issue_actions(context: TimelineContext) -> list[str]:
         close_or_reopen_lines.append(f"⏎ Reopen issue via gh: `gh issue reopen {context.number} --repo {repo}`")
     return [
         "## Actions",
+        "⌨ comment_body: '<comment_body>'",
         f"⏎ Comment via gh: `gh issue comment {context.number} --repo {repo} --body '<comment_body>'`",
         *close_or_reopen_lines,
+        "⌨ labels_csv: '<label1>,<label2>'",
         f"⏎ Add labels via gh: `gh issue edit {context.number} --repo {repo} --add-label '<label1>,<label2>'`",
         f"⏎ Remove labels via gh: `gh issue edit {context.number} --repo {repo} --remove-label '<label1>,<label2>'`",
+        "⌨ assignees_csv: '<assignee1>,<assignee2>'",
         f"⏎ Assign via gh: `gh issue edit {context.number} --repo {repo} --add-assignee '<assignee1>,<assignee2>'`",
     ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -559,7 +559,12 @@ def test_view_and_expand_use_real_cursor_pagination(
     assert "[IN_PROGRESS/NONE] unit-tests (check-run)" in out
     assert "passed checks hidden." in out
     assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
-    assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body-file <path-or->" in out
+    assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
+    assert "⌨ comment_body: '<comment_body>'" not in out
+    assert "⌨ comment_body_file: '<path-or->'" not in out
+    assert "⌨ labels_csv: '<label1>,<label2>'" not in out
+    assert "⌨ reviewers_csv: '<reviewer1>,<reviewer2>'" not in out
+    assert "⌨ assignees_csv: '<assignee1>,<assignee2>'" not in out
     assert "gh pr close 77928 --repo PaddlePaddle/Paddle" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
@@ -570,9 +575,11 @@ def test_view_and_expand_use_real_cursor_pagination(
         "Edit comment via gh-llm: `gh-llm pr comment-edit c3 --body '<comment_body>' --pr 77928 --repo PaddlePaddle/Paddle`"
         in out
     )
+    assert "⌨ comment_body: '<comment_body>'" not in out
+    assert "⌨ comment_body_file: '<comment.md>'" not in out
     assert (
         "Multi-line edit via gh-llm: `gh-llm pr comment-edit c3 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        in out
+        not in out
     )
 
     pre_expand_calls = len(responder.calls)
@@ -618,14 +625,21 @@ def test_view_and_expand_use_real_cursor_pagination(
         "Edit comment via gh-llm: `gh-llm pr comment-edit PRRC_self_1 --body '<comment_body>' --pr 77928 --repo PaddlePaddle/Paddle`"
         in out
     )
-    assert "reply_body_file: '<reply.md>'" in out
+    assert (
+        "Reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body '<reply>' --pr 77928 --repo PaddlePaddle/Paddle`"
+        in out
+    )
+    assert "⌨ reply_body: '<reply>'" not in out
+    assert "⌨ reply_body_file: '<reply.md>'" not in out
+    assert "⌨ comment_body: '<comment_body>'" not in out
+    assert "⌨ comment_body_file: '<comment.md>'" not in out
     assert (
         "Multi-line reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body-file <reply.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        in out
+        not in out
     )
     assert (
         "Multi-line edit via gh-llm: `gh-llm pr comment-edit PRRC_self_1 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        in out
+        not in out
     )
     assert "Unresolve via gh-llm:" in out
 
@@ -1526,7 +1540,11 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
     assert "run `gh-llm issue comment-expand ic1 --issue 77924 --repo PaddlePaddle/Paddle` for full comment" in out
     assert "## Actions" in out
     assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
-    assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body-file <path-or->" in out
+    assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
+    assert "⌨ comment_body: '<comment_body>'" not in out
+    assert "⌨ comment_body_file: '<path-or->'" not in out
+    assert "⌨ labels_csv: '<label1>,<label2>'" not in out
+    assert "⌨ assignees_csv: '<assignee1>,<assignee2>'" not in out
     assert "gh issue close 77924 --repo PaddlePaddle/Paddle" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
@@ -1535,9 +1553,11 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
         "Edit comment via gh-llm: `gh-llm issue comment-edit ic2 --body '<comment_body>' --issue 77924 --repo PaddlePaddle/Paddle`"
         in out
     )
+    assert "⌨ comment_body: '<comment_body>'" not in out
+    assert "⌨ comment_body_file: '<comment.md>'" not in out
     assert (
         "Multi-line edit via gh-llm: `gh-llm issue comment-edit ic2 --body-file <comment.md> --issue 77924 --repo PaddlePaddle/Paddle`"
-        in out
+        not in out
     )
     assert "cross-reference by @alice (Alice)" in out
     assert "gh-llm pr view 77900 --repo PaddlePaddle/Paddle" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -569,6 +569,7 @@ def test_view_and_expand_use_real_cursor_pagination(
         "Edit comment via gh-llm: `gh-llm pr comment-edit c3 --body '<comment_body>' --pr 77928 --repo PaddlePaddle/Paddle`"
         in out
     )
+    assert "⌨ comment_body: '<comment_body>'" in out
 
     pre_expand_calls = len(responder.calls)
     code = cli.run(["pr", "timeline-expand", "2", "--pr", "77928", "--repo", "PaddlePaddle/Paddle", "--page-size", "2"])
@@ -617,6 +618,7 @@ def test_view_and_expand_use_real_cursor_pagination(
         "Reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body '<reply>' --pr 77928 --repo PaddlePaddle/Paddle`"
         in out
     )
+    assert "⌨ comment_body: '<comment_body>'" in out
     assert "⌨ reply_body: '<reply>'" in out
     assert "Unresolve via gh-llm:" in out
 
@@ -1525,6 +1527,7 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
         "Edit comment via gh-llm: `gh-llm issue comment-edit ic2 --body '<comment_body>' --issue 77924 --repo PaddlePaddle/Paddle`"
         in out
     )
+    assert "⌨ comment_body: '<comment_body>'" in out
     assert "cross-reference by @alice (Alice)" in out
     assert "gh-llm pr view 77900 --repo PaddlePaddle/Paddle" in out
     assert "issue/closed by @ShigureNyako" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -559,7 +559,6 @@ def test_view_and_expand_use_real_cursor_pagination(
     assert "[IN_PROGRESS/NONE] unit-tests (check-run)" in out
     assert "passed checks hidden." in out
     assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
-    assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
     assert "gh pr close 77928 --repo PaddlePaddle/Paddle" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
@@ -569,10 +568,6 @@ def test_view_and_expand_use_real_cursor_pagination(
     assert (
         "Edit comment via gh-llm: `gh-llm pr comment-edit c3 --body '<comment_body>' --pr 77928 --repo PaddlePaddle/Paddle`"
         in out
-    )
-    assert (
-        "Multi-line edit via gh-llm: `gh-llm pr comment-edit c3 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        not in out
     )
 
     pre_expand_calls = len(responder.calls)
@@ -623,14 +618,6 @@ def test_view_and_expand_use_real_cursor_pagination(
         in out
     )
     assert "⌨ reply_body: '<reply>'" in out
-    assert (
-        "Multi-line reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body-file <reply.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        not in out
-    )
-    assert (
-        "Multi-line edit via gh-llm: `gh-llm pr comment-edit PRRC_self_1 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        not in out
-    )
     assert "Unresolve via gh-llm:" in out
 
     code = cli.run(
@@ -1530,7 +1517,6 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
     assert "run `gh-llm issue comment-expand ic1 --issue 77924 --repo PaddlePaddle/Paddle` for full comment" in out
     assert "## Actions" in out
     assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
-    assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
     assert "gh issue close 77924 --repo PaddlePaddle/Paddle" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
@@ -1538,10 +1524,6 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
     assert (
         "Edit comment via gh-llm: `gh-llm issue comment-edit ic2 --body '<comment_body>' --issue 77924 --repo PaddlePaddle/Paddle`"
         in out
-    )
-    assert (
-        "Multi-line edit via gh-llm: `gh-llm issue comment-edit ic2 --body-file <comment.md> --issue 77924 --repo PaddlePaddle/Paddle`"
-        not in out
     )
     assert "cross-reference by @alice (Alice)" in out
     assert "gh-llm pr view 77900 --repo PaddlePaddle/Paddle" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -560,11 +560,6 @@ def test_view_and_expand_use_real_cursor_pagination(
     assert "passed checks hidden." in out
     assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
     assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
-    assert "⌨ comment_body: '<comment_body>'" not in out
-    assert "⌨ comment_body_file: '<path-or->'" not in out
-    assert "⌨ labels_csv: '<label1>,<label2>'" not in out
-    assert "⌨ reviewers_csv: '<reviewer1>,<reviewer2>'" not in out
-    assert "⌨ assignees_csv: '<assignee1>,<assignee2>'" not in out
     assert "gh pr close 77928 --repo PaddlePaddle/Paddle" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
@@ -575,8 +570,6 @@ def test_view_and_expand_use_real_cursor_pagination(
         "Edit comment via gh-llm: `gh-llm pr comment-edit c3 --body '<comment_body>' --pr 77928 --repo PaddlePaddle/Paddle`"
         in out
     )
-    assert "⌨ comment_body: '<comment_body>'" not in out
-    assert "⌨ comment_body_file: '<comment.md>'" not in out
     assert (
         "Multi-line edit via gh-llm: `gh-llm pr comment-edit c3 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
         not in out
@@ -629,10 +622,7 @@ def test_view_and_expand_use_real_cursor_pagination(
         "Reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body '<reply>' --pr 77928 --repo PaddlePaddle/Paddle`"
         in out
     )
-    assert "⌨ reply_body: '<reply>'" not in out
-    assert "⌨ reply_body_file: '<reply.md>'" not in out
-    assert "⌨ comment_body: '<comment_body>'" not in out
-    assert "⌨ comment_body_file: '<comment.md>'" not in out
+    assert "⌨ reply_body: '<reply>'" in out
     assert (
         "Multi-line reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body-file <reply.md> --pr 77928 --repo PaddlePaddle/Paddle`"
         not in out
@@ -1541,10 +1531,6 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
     assert "## Actions" in out
     assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
     assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
-    assert "⌨ comment_body: '<comment_body>'" not in out
-    assert "⌨ comment_body_file: '<path-or->'" not in out
-    assert "⌨ labels_csv: '<label1>,<label2>'" not in out
-    assert "⌨ assignees_csv: '<assignee1>,<assignee2>'" not in out
     assert "gh issue close 77924 --repo PaddlePaddle/Paddle" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
@@ -1553,8 +1539,6 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
         "Edit comment via gh-llm: `gh-llm issue comment-edit ic2 --body '<comment_body>' --issue 77924 --repo PaddlePaddle/Paddle`"
         in out
     )
-    assert "⌨ comment_body: '<comment_body>'" not in out
-    assert "⌨ comment_body_file: '<comment.md>'" not in out
     assert (
         "Multi-line edit via gh-llm: `gh-llm issue comment-edit ic2 --body-file <comment.md> --issue 77924 --repo PaddlePaddle/Paddle`"
         not in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -560,7 +560,6 @@ def test_view_and_expand_use_real_cursor_pagination(
     assert "passed checks hidden." in out
     assert "⌨ comment_body: '<comment_body>'" in out
     assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
-    assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
     assert "gh pr close 77928 --repo PaddlePaddle/Paddle" in out
     assert "⌨ labels_csv: '<label1>,<label2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
@@ -575,10 +574,6 @@ def test_view_and_expand_use_real_cursor_pagination(
         in out
     )
     assert "⌨ comment_body: '<comment_body>'" in out
-    assert (
-        "Multi-line edit via gh-llm: `gh-llm pr comment-edit c3 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        not in out
-    )
 
     pre_expand_calls = len(responder.calls)
     code = cli.run(["pr", "timeline-expand", "2", "--pr", "77928", "--repo", "PaddlePaddle/Paddle", "--page-size", "2"])
@@ -629,14 +624,6 @@ def test_view_and_expand_use_real_cursor_pagination(
     )
     assert "⌨ comment_body: '<comment_body>'" in out
     assert "⌨ reply_body: '<reply>'" in out
-    assert (
-        "Multi-line reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body-file <reply.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        not in out
-    )
-    assert (
-        "Multi-line edit via gh-llm: `gh-llm pr comment-edit PRRC_self_1 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
-        not in out
-    )
     assert "Unresolve via gh-llm:" in out
 
     code = cli.run(
@@ -1537,7 +1524,6 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
     assert "## Actions" in out
     assert "⌨ comment_body: '<comment_body>'" in out
     assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
-    assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
     assert "gh issue close 77924 --repo PaddlePaddle/Paddle" in out
     assert "⌨ labels_csv: '<label1>,<label2>'" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
@@ -1549,10 +1535,6 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
         in out
     )
     assert "⌨ comment_body: '<comment_body>'" in out
-    assert (
-        "Multi-line edit via gh-llm: `gh-llm issue comment-edit ic2 --body-file <comment.md> --issue 77924 --repo PaddlePaddle/Paddle`"
-        not in out
-    )
     assert "cross-reference by @alice (Alice)" in out
     assert "gh-llm pr view 77900 --repo PaddlePaddle/Paddle" in out
     assert "issue/closed by @ShigureNyako" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -558,11 +558,16 @@ def test_view_and_expand_use_real_cursor_pagination(
     assert "## Checks" in out
     assert "[IN_PROGRESS/NONE] unit-tests (check-run)" in out
     assert "passed checks hidden." in out
+    assert "⌨ comment_body: '<comment_body>'" in out
     assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
+    assert "gh pr comment 77928 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
     assert "gh pr close 77928 --repo PaddlePaddle/Paddle" in out
+    assert "⌨ labels_csv: '<label1>,<label2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
+    assert "⌨ reviewers_csv: '<reviewer1>,<reviewer2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --add-reviewer '<reviewer1>,<reviewer2>'" in out
+    assert "⌨ assignees_csv: '<assignee1>,<assignee2>'" in out
     assert "gh pr edit 77928 --repo PaddlePaddle/Paddle --add-assignee '<assignee1>,<assignee2>'" in out
     assert "link:" not in out
     assert (
@@ -570,6 +575,10 @@ def test_view_and_expand_use_real_cursor_pagination(
         in out
     )
     assert "⌨ comment_body: '<comment_body>'" in out
+    assert (
+        "Multi-line edit via gh-llm: `gh-llm pr comment-edit c3 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
+        not in out
+    )
 
     pre_expand_calls = len(responder.calls)
     code = cli.run(["pr", "timeline-expand", "2", "--pr", "77928", "--repo", "PaddlePaddle/Paddle", "--page-size", "2"])
@@ -620,6 +629,14 @@ def test_view_and_expand_use_real_cursor_pagination(
     )
     assert "⌨ comment_body: '<comment_body>'" in out
     assert "⌨ reply_body: '<reply>'" in out
+    assert (
+        "Multi-line reply via gh-llm: `gh-llm pr thread-reply PRRT_mock_1 --body-file <reply.md> --pr 77928 --repo PaddlePaddle/Paddle`"
+        not in out
+    )
+    assert (
+        "Multi-line edit via gh-llm: `gh-llm pr comment-edit PRRC_self_1 --body-file <comment.md> --pr 77928 --repo PaddlePaddle/Paddle`"
+        not in out
+    )
     assert "Unresolve via gh-llm:" in out
 
     code = cli.run(
@@ -1518,16 +1535,24 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
     assert "(comment hidden: outdated)" in out
     assert "run `gh-llm issue comment-expand ic1 --issue 77924 --repo PaddlePaddle/Paddle` for full comment" in out
     assert "## Actions" in out
+    assert "⌨ comment_body: '<comment_body>'" in out
     assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body '<comment_body>'" in out
+    assert "gh issue comment 77924 --repo PaddlePaddle/Paddle --body-file <path-or->" not in out
     assert "gh issue close 77924 --repo PaddlePaddle/Paddle" in out
+    assert "⌨ labels_csv: '<label1>,<label2>'" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --add-label '<label1>,<label2>'" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --remove-label '<label1>,<label2>'" in out
+    assert "⌨ assignees_csv: '<assignee1>,<assignee2>'" in out
     assert "gh issue edit 77924 --repo PaddlePaddle/Paddle --add-assignee '<assignee1>,<assignee2>'" in out
     assert (
         "Edit comment via gh-llm: `gh-llm issue comment-edit ic2 --body '<comment_body>' --issue 77924 --repo PaddlePaddle/Paddle`"
         in out
     )
     assert "⌨ comment_body: '<comment_body>'" in out
+    assert (
+        "Multi-line edit via gh-llm: `gh-llm issue comment-edit ic2 --body-file <comment.md> --issue 77924 --repo PaddlePaddle/Paddle`"
+        not in out
+    )
     assert "cross-reference by @alice (Alice)" in out
     assert "gh-llm pr view 77900 --repo PaddlePaddle/Paddle" in out
     assert "issue/closed by @ShigureNyako" in out


### PR DESCRIPTION
## Summary
- 精简 issue / PR 顶层 `Actions` 区块，去掉占位输入行和重复的 `--body-file` 提示
- 精简 timeline comment / review thread / review comment 的内联 actions，只保留最常用的单行命令
- 更新 CLI 测试，确保保留的命令仍可见，同时防止噪声提示回归

## Validation
- `uv run pyright src/gh_llm tests`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`

Closes #44.

@SigureMo PTAL