### PR TITLE
✨ feat: auto-collapse timeline authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ gh-llm pr timeline-expand 2 --pr 77900 --repo PaddlePaddle/Paddle --after 2026-0
 gh-llm pr view 77900 --repo PaddlePaddle/Paddle --expand resolved,minimized
 gh-llm pr timeline-expand 2 --pr 77900 --repo PaddlePaddle/Paddle --expand all
 
+# Auto-collapse noisy comment/review authors in timeline output
+gh-llm pr view 77900 --repo PaddlePaddle/Paddle --auto-collapse-author PaddlePaddle-bot
+gh-llm pr timeline-expand 2 --pr 77900 --repo PaddlePaddle/Paddle --auto-collapse-author PaddlePaddle-bot,other-bot
+
 # Show full content for one comment node id
 gh-llm pr comment-expand IC_xxx --pr 77900 --repo PaddlePaddle/Paddle
 
@@ -125,6 +129,7 @@ gh-llm issue view 77924 --repo PaddlePaddle/Paddle
 gh-llm issue view 77924 --repo PaddlePaddle/Paddle --after 2026-04-08T02:41:17Z
 gh-llm issue timeline-expand 2 --issue 77924 --repo PaddlePaddle/Paddle
 gh-llm issue timeline-expand 2 --issue 77924 --repo PaddlePaddle/Paddle --after 2026-04-08T02:41:17Z
+gh-llm issue view 77924 --repo PaddlePaddle/Paddle --auto-collapse-author PaddlePaddle-bot
 gh-llm issue comment-expand IC_xxx --issue 77924 --repo PaddlePaddle/Paddle
 gh-llm issue view 77924 --repo PaddlePaddle/Paddle --expand minimized,details
 gh-llm issue view 77924 --repo PaddlePaddle/Paddle --show meta,description
@@ -135,6 +140,8 @@ For incremental follow-ups, copy the previous output's `fetched_at` value into `
 When `--show` does not include `timeline` (for example `--show meta`, `--show summary`, or `--show actions`), both `pr view` and `issue view` stay on the lightweight metadata path and skip timeline bootstrap.
 
 Use `--show` to choose which output sections to render. Use `--expand` to automatically open folded content within those sections.
+
+Use `--auto-collapse-author <login>` on `pr view`, `pr timeline-expand`, `issue view`, or `issue timeline-expand` to replace selected authors' timeline comments/reviews with a compact placeholder that includes author, node/review id, and body size. Values are case-insensitive, may start with `@`, and support comma-separated or repeated flags. Without this option, output is unchanged. To view full content, run the emitted `comment-expand` / `review-expand` command, or rerun without `--auto-collapse-author`.
 
 `--expand` values:
 

--- a/src/gh_llm/commands/issue.py
+++ b/src/gh_llm/commands/issue.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from gh_llm.commands.options import (
+    add_auto_collapse_author_argument,
     add_body_input_arguments,
     add_timeline_window_arguments,
     maybe_resolve_subject,
+    parse_auto_collapse_authors,
     parse_timeline_window,
     raise_unknown_option_value,
     resolve_file_or_inline_text,
@@ -68,6 +70,7 @@ def register_issue_parser(subparsers: Any) -> None:
         help="auto-expand folded content: minimized, details, all (comma-separated or repeatable)",
     )
     add_timeline_window_arguments(view_parser)
+    add_auto_collapse_author_argument(view_parser)
     view_parser.set_defaults(handler=cmd_issue_view)
 
     timeline_expand_parser = issue_subparsers.add_parser("timeline-expand", help="load one timeline page by number")
@@ -82,6 +85,7 @@ def register_issue_parser(subparsers: Any) -> None:
         help="auto-expand folded content: minimized, details, all (comma-separated or repeatable)",
     )
     add_timeline_window_arguments(timeline_expand_parser)
+    add_auto_collapse_author_argument(timeline_expand_parser)
     timeline_expand_parser.set_defaults(handler=cmd_issue_timeline_expand)
 
     details_expand_parser = issue_subparsers.add_parser(
@@ -119,11 +123,16 @@ def cmd_issue_view(args: Any) -> int:
     expand = _parse_expand_options(raw_values=list(getattr(args, "expand", [])))
     show = _parse_show_options(raw_values=list(getattr(args, "show", [])))
     timeline_window = _resolve_timeline_window(args)
+    auto_collapse_authors = _resolve_auto_collapse_authors(args)
     client = GitHubClient()
     pager = TimelinePager(client)
 
     meta = _resolve_issue_meta(client=client, args=args)
-    context = build_context_from_meta(meta=meta, page_size=page_size)
+    context = build_context_from_meta(
+        meta=meta,
+        page_size=page_size,
+        auto_collapse_authors=auto_collapse_authors,
+    )
     first_page: TimelinePage | None = None
     last_page: TimelinePage | None = None
     shown_pages: set[int] = set()
@@ -135,6 +144,7 @@ def cmd_issue_view(args: Any) -> int:
             timeline_window=timeline_window,
             show_minimized_details=expand.minimized,
             show_details_blocks=expand.details,
+            auto_collapse_authors=auto_collapse_authors,
         )
         shown_pages.add(1)
 
@@ -208,6 +218,7 @@ def cmd_issue_timeline_expand(args: Any) -> int:
         args=args,
         show_minimized_details=expand.minimized,
         show_details_blocks=expand.details,
+        auto_collapse_authors=_resolve_auto_collapse_authors(args),
     )
 
     page = pager.fetch_page(
@@ -309,6 +320,7 @@ def _resolve_context_and_meta(
     args: Any,
     show_minimized_details: bool = False,
     show_details_blocks: bool = False,
+    auto_collapse_authors: tuple[str, ...] = (),
 ) -> tuple[TimelineContext, PullRequestMeta]:
     page_size = getattr(args, "page_size", None)
     effective_page_size = DEFAULT_PAGE_SIZE if page_size is None else int(page_size)
@@ -319,12 +331,17 @@ def _resolve_context_and_meta(
         timeline_window=_resolve_timeline_window(args),
         show_minimized_details=show_minimized_details,
         show_details_blocks=show_details_blocks,
+        auto_collapse_authors=auto_collapse_authors,
     )
     return context, meta
 
 
 def _resolve_timeline_window(args: Any):
     return parse_timeline_window(after=getattr(args, "after", None), before=getattr(args, "before", None))
+
+
+def _resolve_auto_collapse_authors(args: Any) -> tuple[str, ...]:
+    return parse_auto_collapse_authors(raw_values=list(getattr(args, "auto_collapse_author", [])))
 
 
 def _resolve_timeline_page_for_index(*, context: TimelineContext, index: int) -> int | None:

--- a/src/gh_llm/commands/options.py
+++ b/src/gh_llm/commands/options.py
@@ -43,6 +43,32 @@ def add_timeline_window_arguments(parser: Any) -> None:
     )
 
 
+def add_auto_collapse_author_argument(parser: Any) -> None:
+    parser.add_argument(
+        "--auto-collapse-author",
+        action="append",
+        default=[],
+        metavar="LOGIN",
+        help="auto-collapse timeline comments/reviews from GitHub login(s), comma-separated or repeatable",
+    )
+
+
+def parse_auto_collapse_authors(*, raw_values: list[str]) -> tuple[str, ...]:
+    authors: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        for part in raw.split(","):
+            token = part.strip().lstrip("@").strip()
+            if not token:
+                continue
+            normalized = token.casefold()
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            authors.append(token)
+    return tuple(authors)
+
+
 def parse_timeline_window(*, after: str | None, before: str | None) -> TimelineWindow:
     after_value = _parse_timestamp(raw=after, flag="--after")
     before_value = _parse_timestamp(raw=before, flag="--before")

--- a/src/gh_llm/commands/pr.py
+++ b/src/gh_llm/commands/pr.py
@@ -10,9 +10,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from gh_llm.commands.options import (
+    add_auto_collapse_author_argument,
     add_body_input_arguments,
     add_timeline_window_arguments,
     maybe_resolve_subject,
+    parse_auto_collapse_authors,
     parse_timeline_window,
     raise_unknown_option_value,
     resolve_file_or_inline_text,
@@ -99,6 +101,7 @@ def register_pr_parser(subparsers: Any) -> None:
         help="max lines for each review diff hunk (<=0 means full)",
     )
     add_timeline_window_arguments(view_parser)
+    add_auto_collapse_author_argument(view_parser)
     view_parser.set_defaults(handler=cmd_pr_view)
 
     timeline_expand_parser = pr_subparsers.add_parser("timeline-expand", help="expand a specific timeline page")
@@ -119,6 +122,7 @@ def register_pr_parser(subparsers: Any) -> None:
         help="max lines for each review diff hunk (<=0 means full)",
     )
     add_timeline_window_arguments(timeline_expand_parser)
+    add_auto_collapse_author_argument(timeline_expand_parser)
     timeline_expand_parser.set_defaults(handler=cmd_pr_timeline_expand)
 
     details_expand_parser = pr_subparsers.add_parser(
@@ -382,11 +386,16 @@ def cmd_pr_view(args: Any) -> int:
     expand = _parse_expand_options(raw_values=list(getattr(args, "expand", [])))
     show = _parse_show_options(raw_values=list(getattr(args, "show", [])))
     timeline_window = _resolve_timeline_window(args)
+    auto_collapse_authors = _resolve_auto_collapse_authors(args)
     client = GitHubClient()
     pager = TimelinePager(client)
 
     meta = _resolve_pr_meta(client=client, args=args)
-    context = build_context_from_meta(meta=meta, page_size=page_size)
+    context = build_context_from_meta(
+        meta=meta,
+        page_size=page_size,
+        auto_collapse_authors=auto_collapse_authors,
+    )
     first_page: TimelinePage | None = None
     last_page: TimelinePage | None = None
     shown_pages: set[int] = set()
@@ -401,6 +410,7 @@ def cmd_pr_view(args: Any) -> int:
             show_minimized_details=expand.minimized,
             show_details_blocks=expand.details,
             diff_hunk_lines=diff_hunk_lines,
+            auto_collapse_authors=auto_collapse_authors,
         )
         shown_pages.add(1)
 
@@ -501,6 +511,7 @@ def cmd_pr_timeline_expand(args: Any) -> int:
         show_minimized_details=expand.minimized,
         show_details_blocks=expand.details,
         diff_hunk_lines=diff_hunk_lines,
+        auto_collapse_authors=_resolve_auto_collapse_authors(args),
     )
 
     page = pager.fetch_page(
@@ -1163,6 +1174,7 @@ def _resolve_context_and_meta(
     show_minimized_details: bool = False,
     show_details_blocks: bool = False,
     diff_hunk_lines: int | None = DEFAULT_DIFF_HUNK_LINES,
+    auto_collapse_authors: tuple[str, ...] = (),
 ) -> tuple[TimelineContext, PullRequestMeta]:
     page_size = getattr(args, "page_size", None)
     effective_page_size = DEFAULT_PAGE_SIZE if page_size is None else int(page_size)
@@ -1176,12 +1188,17 @@ def _resolve_context_and_meta(
         show_minimized_details=show_minimized_details,
         show_details_blocks=show_details_blocks,
         diff_hunk_lines=diff_hunk_lines,
+        auto_collapse_authors=auto_collapse_authors,
     )
     return context, meta
 
 
 def _resolve_timeline_window(args: Any):
     return parse_timeline_window(after=getattr(args, "after", None), before=getattr(args, "before", None))
+
+
+def _resolve_auto_collapse_authors(args: Any) -> tuple[str, ...]:
+    return parse_auto_collapse_authors(raw_values=list(getattr(args, "auto_collapse_author", [])))
 
 
 def _resolve_timeline_page_for_index(*, context: TimelineContext, index: int) -> int | None:

--- a/src/gh_llm/github_api.py
+++ b/src/gh_llm/github_api.py
@@ -2335,6 +2335,8 @@ def _parse_node(
     typename = str(node.get("__typename") or "")
     if typename == "IssueComment":
         body = _as_optional_str(node.get("body"))
+        author = node.get("author")
+        actor_login = _get_login(author)
         details_collapsed_count = 0
         display_body = body
         if not show_details_blocks:
@@ -2349,34 +2351,38 @@ def _parse_node(
         return TimelineEvent(
             timestamp=_parse_datetime(_as_optional_str(node.get("createdAt"))),
             kind="comment",
-            actor=_get_actor_display(node.get("author")),
+            actor=_get_actor_display(author),
             summary=summary,
             source_id=_as_optional_str(node.get("id")) or "comment",
+            actor_login=actor_login,
             full_text=display_body,
             is_truncated=is_truncated,
-            editable_comment_id=(
-                _as_optional_str(node.get("id")) if _get_login(node.get("author")) == viewer_login else None
-            ),
+            editable_comment_id=(_as_optional_str(node.get("id")) if actor_login == viewer_login else None),
             reactions_summary=_format_reactions(node.get("reactionGroups")),
             details_collapsed_count=details_collapsed_count,
+            auto_collapse_kind="comment",
         )
 
     if typename == "PullRequestReview":
         state = _as_optional_str(node.get("state")) or "COMMENTED"
         review_id = _as_optional_str(node.get("id")) or "review"
+        author = node.get("author")
+        actor_login = _get_login(author)
         is_minimized = bool(node.get("isMinimized"))
         minimized_reason = _format_minimized_reason(node.get("minimizedReason"))
         if is_minimized and not show_minimized_details:
             return TimelineEvent(
                 timestamp=_parse_datetime(_as_optional_str(node.get("submittedAt"))),
                 kind=f"review/{state.lower()}",
-                actor=_get_actor_display(node.get("author")),
+                actor=_get_actor_display(author),
                 summary=f"(review hidden: {minimized_reason})",
                 source_id=review_id,
+                actor_login=actor_login,
                 full_text=_as_optional_str(node.get("body")),
                 is_truncated=True,
                 minimized_hidden_count=1,
                 minimized_hidden_reasons=minimized_reason,
+                auto_collapse_kind="review",
             )
         full_review, resolved_hidden_count, has_clipped_diff_hunk, details_collapsed_count = _build_review_text(
             node=node,
@@ -2405,9 +2411,10 @@ def _parse_node(
         return TimelineEvent(
             timestamp=_parse_datetime(_as_optional_str(node.get("submittedAt"))),
             kind=f"review/{state.lower()}",
-            actor=_get_actor_display(node.get("author")),
+            actor=_get_actor_display(author),
             summary=summary,
             source_id=review_id,
+            actor_login=actor_login,
             full_text=full_review,
             related_timestamps=_collect_review_comment_timestamps(threads_for_review.get(review_id, [])),
             is_truncated=has_clipped_diff_hunk,
@@ -2415,6 +2422,7 @@ def _parse_node(
             minimized_hidden_count=minimized_hidden_count,
             minimized_hidden_reasons=minimized_hidden_reasons,
             details_collapsed_count=details_collapsed_count,
+            auto_collapse_kind="review",
         )
 
     if typename == "ReviewDismissedEvent":

--- a/src/gh_llm/models.py
+++ b/src/gh_llm/models.py
@@ -79,6 +79,7 @@ class TimelineEvent:
     actor: str
     summary: str
     source_id: str
+    actor_login: str | None = None
     full_text: str | None = None
     related_timestamps: tuple[datetime, ...] = ()
     is_truncated: bool = False
@@ -88,6 +89,7 @@ class TimelineEvent:
     editable_comment_id: str | None = None
     reactions_summary: str | None = None
     details_collapsed_count: int = 0
+    auto_collapse_kind: str | None = None
 
 
 @dataclass(frozen=True)
@@ -214,6 +216,7 @@ class TimelineContext:
     timeline_before: str | None = None
     timeline_unfiltered_count: int | None = None
     timeline_filtered: bool = False
+    auto_collapse_authors: tuple[str, ...] = ()
     labels: tuple[str, ...] = ()
     kind: str = "pr"
     pr_reactions_summary: str | None = None
@@ -264,6 +267,7 @@ class TimelineContext:
             "timeline_before": self.timeline_before,
             "timeline_unfiltered_count": self.timeline_unfiltered_count,
             "timeline_filtered": self.timeline_filtered,
+            "auto_collapse_authors": list(self.auto_collapse_authors),
             "labels": list(self.labels),
             "kind": self.kind,
             "pr_reactions_summary": self.pr_reactions_summary,
@@ -323,6 +327,9 @@ class TimelineContext:
                 else _as_int(value.get("timeline_unfiltered_count"), 0)
             ),
             timeline_filtered=bool(value.get("timeline_filtered")),
+            auto_collapse_authors=tuple(
+                _as_str(item, "").lstrip("@") for item in _as_list(value.get("auto_collapse_authors")) if item
+            ),
             labels=tuple(_as_str(item, "") for item in _as_list(value.get("labels")) if item),
             kind=_as_str(value.get("kind"), "pr"),
             pr_reactions_summary=_as_str_optional(value.get("pr_reactions_summary")),

--- a/src/gh_llm/pager.py
+++ b/src/gh_llm/pager.py
@@ -24,6 +24,7 @@ def build_context_from_meta(
     timeline_before: str | None = None,
     timeline_unfiltered_count: int | None = None,
     timeline_filtered: bool = False,
+    auto_collapse_authors: tuple[str, ...] = (),
     filtered_pages: dict[int, TimelinePage] | None = None,
 ) -> TimelineContext:
     _validate_page_size(page_size)
@@ -52,6 +53,7 @@ def build_context_from_meta(
         timeline_before=timeline_before,
         timeline_unfiltered_count=timeline_unfiltered_count,
         timeline_filtered=timeline_filtered,
+        auto_collapse_authors=auto_collapse_authors,
         labels=meta.labels,
         kind=meta.kind,
         pr_reactions_summary=meta.reactions_summary,
@@ -99,6 +101,7 @@ class TimelinePager:
         show_details_blocks: bool = False,
         review_threads_window: int | None = 10,
         diff_hunk_lines: int | None = None,
+        auto_collapse_authors: tuple[str, ...] = (),
     ) -> tuple[TimelineContext, TimelinePage, TimelinePage | None]:
         _validate_page_size(page_size)
         window = TimelineWindow() if timeline_window is None else timeline_window
@@ -116,6 +119,7 @@ class TimelinePager:
                 show_details_blocks=show_details_blocks,
                 review_threads_window=review_threads_window,
                 diff_hunk_lines=diff_hunk_lines,
+                auto_collapse_authors=auto_collapse_authors,
             )
 
         first_page = self._client.fetch_timeline_forward(
@@ -147,6 +151,7 @@ class TimelinePager:
             total_count=total_count,
             total_pages=total_pages,
             fetched_at=fetched_at,
+            auto_collapse_authors=auto_collapse_authors,
         )
         self._remember_forward(context, page=1, cursor_used=None, page_result=first_page)
 
@@ -296,6 +301,7 @@ class TimelinePager:
         show_details_blocks: bool,
         review_threads_window: int | None,
         diff_hunk_lines: int | None,
+        auto_collapse_authors: tuple[str, ...],
     ) -> tuple[TimelineContext, TimelinePage, TimelinePage | None]:
         if timeline_window.after is not None:
             collected, total_count = self._collect_filtered_from_end(
@@ -335,6 +341,7 @@ class TimelinePager:
             timeline_before=timeline_window.before_text,
             timeline_unfiltered_count=total_count,
             timeline_filtered=True,
+            auto_collapse_authors=auto_collapse_authors,
             filtered_pages=filtered_pages,
         )
         first_page = filtered_pages[1]

--- a/src/gh_llm/render.py
+++ b/src/gh_llm/render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 from datetime import UTC
 from typing import TYPE_CHECKING, cast
 
@@ -48,6 +49,11 @@ def render_frontmatter(context: TimelineContext) -> list[str]:
                 ),
                 *([f"timeline_after: {context.timeline_after}"] if context.timeline_after else []),
                 *([f"timeline_before: {context.timeline_before}"] if context.timeline_before else []),
+                *(
+                    [f"auto_collapse_authors: {json.dumps(list(context.auto_collapse_authors), ensure_ascii=False)}"]
+                    if context.auto_collapse_authors
+                    else []
+                ),
                 f"page_size: {context.page_size}",
                 f"total_pages: {context.total_pages}",
             ]
@@ -379,7 +385,7 @@ def render_hidden_gap(context: TimelineContext, hidden_pages: list[int]) -> list
         return []
     repo = f"{context.owner}/{context.name}"
     selector_name = "issue" if context.kind == "issue" else "pr"
-    filter_flags = _timeline_filter_flags(context)
+    timeline_expand_flags = _timeline_expand_flags(context)
     hidden_label = (
         f"Hidden timeline page: {hidden_pages[0]}"
         if len(hidden_pages) == 1
@@ -390,7 +396,7 @@ def render_hidden_gap(context: TimelineContext, hidden_pages: list[int]) -> list
         hidden_label,
         *[
             _render_template(
-                t"- ⏎ `{display_command_with(f'{context.kind} timeline-expand {page} --{selector_name} {context.number} --repo {repo}{filter_flags}')}`"
+                t"- ⏎ `{display_command_with(f'{context.kind} timeline-expand {page} --{selector_name} {context.number} --repo {repo}{timeline_expand_flags}')}`"
             )
             for page in hidden_pages
         ],
@@ -411,6 +417,24 @@ def _render_item(index: int, event: TimelineEvent, context: TimelineContext, com
         f"(details body collapsed; {details_action})",
     )
     lines = [f"{index}. [{timestamp}] {event.kind} by @{event.actor}"]
+    auto_collapse_summary = _auto_collapse_summary(event=event, context=context)
+    if auto_collapse_summary is not None:
+        repo = f"{context.owner}/{context.name}"
+        if event.auto_collapse_kind == "comment":
+            lines.append("   Comment:")
+            lines.extend(_indented_tag_block("comment", auto_collapse_summary, indent="   "))
+            if event.reactions_summary:
+                lines.append(f"   Reactions: {event.reactions_summary}")
+            lines.append(
+                f"   ⏎ run `{display_command_with(f'{command_group} comment-expand {event.source_id} --{selector_name} {context.number} --repo {repo}')}` for full comment"
+            )
+            return lines
+        if event.auto_collapse_kind == "review":
+            lines.extend(_indent_block(auto_collapse_summary))
+            lines.append(
+                f"   ⏎ run `{display_command_with(f'pr review-expand {event.source_id} --pr {context.number} --repo {repo}')}` for full review"
+            )
+            return lines
     if event.kind == "comment":
         lines.append("   Comment:")
         lines.extend(_indented_tag_block("comment", display_summary, indent="   "))
@@ -449,6 +473,35 @@ def _render_item(index: int, event: TimelineEvent, context: TimelineContext, com
     return lines
 
 
+def _auto_collapse_summary(*, event: TimelineEvent, context: TimelineContext) -> str | None:
+    if not context.auto_collapse_authors or event.auto_collapse_kind not in {"comment", "review"}:
+        return None
+    actor_login = event.actor_login or ""
+    if not actor_login:
+        return None
+    selected = {author.casefold() for author in context.auto_collapse_authors}
+    if actor_login.casefold() not in selected:
+        return None
+
+    body_text = event.full_text if event.full_text is not None else event.summary
+    line_count, char_count = _text_stats(body_text)
+    id_label = "review_id" if event.auto_collapse_kind == "review" else "node_id"
+    return "\n".join(
+        [
+            f"(auto-collapsed {event.auto_collapse_kind} from @{event.actor})",
+            f"author: @{event.actor}",
+            f"{id_label}: {event.source_id}",
+            f"body: {line_count} lines, {char_count} chars",
+        ]
+    )
+
+
+def _text_stats(text: str) -> tuple[int, int]:
+    if not text:
+        return 0, 0
+    return len(text.splitlines()), len(text)
+
+
 def _render_template(template: Template) -> str:
     rendered: list[str] = []
     for index, segment in enumerate(template.strings):
@@ -477,6 +530,17 @@ def _timeline_filter_flags(context: TimelineContext) -> str:
         parts.extend(["--after", context.timeline_after])
     if context.timeline_before:
         parts.extend(["--before", context.timeline_before])
+    return (" " + " ".join(parts)) if parts else ""
+
+
+def _timeline_expand_flags(context: TimelineContext) -> str:
+    parts: list[str] = []
+    if context.timeline_after:
+        parts.extend(["--after", context.timeline_after])
+    if context.timeline_before:
+        parts.extend(["--before", context.timeline_before])
+    for author in context.auto_collapse_authors:
+        parts.extend(["--auto-collapse-author", shlex.quote(author)])
     return (" " + " ".join(parts)) if parts else ""
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -737,6 +737,100 @@ def test_view_and_expand_use_real_cursor_pagination(
     assert "END_MARKER" in out
 
 
+def test_pr_view_without_auto_collapse_keeps_default_timeline_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    responder = GhResponder()
+    monkeypatch.setattr(github_api.subprocess, "run", responder.run)
+
+    code = cli.run(["pr", "view", "77928", "--repo", "PaddlePaddle/Paddle", "--page-size", "2"])
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "auto_collapse_authors:" not in out
+    assert "auto-collapsed" not in out
+    assert "LONG_TEXT" in out
+    assert "END_MARKER" in out
+
+
+def test_pr_view_auto_collapse_author_collapses_selected_comments_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    responder = GhResponder()
+    monkeypatch.setattr(github_api.subprocess, "run", responder.run)
+
+    code = cli.run(
+        [
+            "pr",
+            "view",
+            "77928",
+            "--repo",
+            "PaddlePaddle/Paddle",
+            "--page-size",
+            "2",
+            "--auto-collapse-author",
+            "@BOT",
+        ]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert 'auto_collapse_authors: ["BOT"]' in out
+    assert "[2026-02-14 14:31 UTC] comment by @bot" in out
+    assert "(auto-collapsed comment from @bot)" in out
+    assert "node_id: c1" in out
+    assert "body: 1 lines," in out
+    assert "gh-llm pr comment-expand c1 --pr 77928 --repo PaddlePaddle/Paddle" in out
+    assert "gh-llm pr timeline-expand 2 --pr 77928 --repo PaddlePaddle/Paddle --auto-collapse-author BOT" in out
+    assert "self comment" in out
+    assert "END_MARKER" not in out
+
+
+def test_pr_view_auto_collapse_author_collapses_selected_reviews(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def events_with_noisy_review() -> list[dict[str, Any]]:
+        events = _base_events()
+        events[4] = {
+            **events[4],
+            "body": "review body from noisy bot",
+            "isMinimized": False,
+            "minimizedReason": None,
+            "author": {"login": "PaddlePaddle-bot"},
+        }
+        return events
+
+    responder = GhResponder()
+    monkeypatch.setattr(github_api.subprocess, "run", responder.run)
+    monkeypatch.setattr(sys.modules[__name__], "_events", events_with_noisy_review)
+
+    code = cli.run(
+        [
+            "pr",
+            "view",
+            "77928",
+            "--repo",
+            "PaddlePaddle/Paddle",
+            "--page-size",
+            "2",
+            "--auto-collapse-author",
+            "PaddlePaddle-bot",
+        ]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "5. [2026-02-14 14:51 UTC] review/approved by @PaddlePaddle-bot" in out
+    assert "(auto-collapsed review from @PaddlePaddle-bot)" in out
+    assert "review_id: PRR_mock" in out
+    assert "gh-llm pr review-expand PRR_mock --pr 77928 --repo PaddlePaddle/Paddle" in out
+    assert "review body from noisy bot" not in out
+    assert "self comment" in out
+
+
 def test_pr_view_after_filters_incremental_events_and_avoids_forward_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1557,6 +1651,37 @@ def test_issue_view_and_expand_use_real_cursor_pagination(
     out = capsys.readouterr().out
     assert "## Comment ic1" in out
     assert "- Type: IssueComment" in out
+
+
+def test_issue_view_auto_collapse_author_collapses_selected_comments(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    responder = GhResponder()
+    monkeypatch.setattr(github_api.subprocess, "run", responder.run)
+
+    code = cli.run(
+        [
+            "issue",
+            "view",
+            "77924",
+            "--repo",
+            "PaddlePaddle/Paddle",
+            "--page-size",
+            "2",
+            "--auto-collapse-author",
+            "bot",
+        ]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert 'auto_collapse_authors: ["bot"]' in out
+    assert "(auto-collapsed comment from @bot)" in out
+    assert "node_id: ic1" in out
+    assert "gh-llm issue comment-expand ic1 --issue 77924 --repo PaddlePaddle/Paddle" in out
+    assert "self issue comment" in out
+    assert "ISSUE_END_MARKER" not in out
 
 
 def test_extract_diff_hunks_prefers_first_added_line_for_right_side() -> None:

--- a/tests/test_command_options.py
+++ b/tests/test_command_options.py
@@ -52,6 +52,14 @@ def test_maybe_resolve_subject_skips_resolution_without_selector() -> None:
     assert called is False
 
 
+def test_parse_auto_collapse_authors_accepts_commas_repeats_and_at_prefixes() -> None:
+    resolved = command_options.parse_auto_collapse_authors(
+        raw_values=["PaddlePaddle-bot,@other", "@paddlepaddle-BOT", "  third  "]
+    )
+
+    assert resolved == ("PaddlePaddle-bot", "other", "third")
+
+
 def test_resolve_file_or_inline_text_treats_empty_file_path_as_provided(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Add `--auto-collapse-author` to `pr view`, `pr timeline-expand`, `issue view`, and `issue timeline-expand`.
- Collapse matching timeline comments/reviews into placeholders that keep author, node/review id, and body size, with `comment-expand` / `review-expand` commands for full content.
- Preserve auto-collapse flags in hidden timeline page expansion hints and document the workflow.

## Usage

```bash
gh-llm pr view 77900 --repo PaddlePaddle/Paddle --auto-collapse-author PaddlePaddle-bot
gh-llm pr timeline-expand 2 --pr 77900 --repo PaddlePaddle/Paddle --auto-collapse-author PaddlePaddle-bot,other-bot
gh-llm issue view 77924 --repo PaddlePaddle/Paddle --auto-collapse-author PaddlePaddle-bot
```

Without `--auto-collapse-author`, timeline output is unchanged.

## Validation

- `just ci-fmt-check`
- `just lint`
- `just test`
