### PR TITLE
:fire: chore: remove PEP 563 future annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,18 +68,14 @@ select = [
   "RSE",
   # Refurb
   "FURB",
-  # Flake8-future-annotations
-  "FA",
   # Yesqa
   "RUF100",
 ]
 ignore = [
   "E501", # line too long, duplicate with ruff fmt
 ]
-future-annotations = true
 
 [tool.ruff.lint.isort]
-required-imports = ["from __future__ import annotations"]
 known-first-party = ["gh_llm"]
 combine-as-imports = true
 

--- a/src/gh_llm/__init__.py
+++ b/src/gh_llm/__init__.py
@@ -1,6 +1,4 @@
 # Meta information for the project.
-from __future__ import annotations
-
 __version__ = "0.1.16"
 __author__ = "Nyakku Shigure"
 __year__ = "2026"

--- a/src/gh_llm/__main__.py
+++ b/src/gh_llm/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 
 from gh_llm.cli import run

--- a/src/gh_llm/cli.py
+++ b/src/gh_llm/cli.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import shlex
 import sys

--- a/src/gh_llm/commands/__init__.py
+++ b/src/gh_llm/commands/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/src/gh_llm/commands/doctor.py
+++ b/src/gh_llm/commands/doctor.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import os
 import shlex

--- a/src/gh_llm/commands/issue.py
+++ b/src/gh_llm/commands/issue.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 

--- a/src/gh_llm/commands/options.py
+++ b/src/gh_llm/commands/options.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from datetime import UTC, datetime
 from difflib import get_close_matches

--- a/src/gh_llm/commands/pr.py
+++ b/src/gh_llm/commands/pr.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import os
 import re

--- a/src/gh_llm/commands/repo.py
+++ b/src/gh_llm/commands/repo.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING, Any
 
 from gh_llm.github_api import GitHubClient

--- a/src/gh_llm/diagnostics.py
+++ b/src/gh_llm/diagnostics.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import shlex
 from dataclasses import dataclass
 from typing import TYPE_CHECKING

--- a/src/gh_llm/environment.py
+++ b/src/gh_llm/environment.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import shlex
 from typing import TYPE_CHECKING

--- a/src/gh_llm/github_api.py
+++ b/src/gh_llm/github_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import binascii
 import json

--- a/src/gh_llm/invocation.py
+++ b/src/gh_llm/invocation.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from pathlib import Path
 

--- a/src/gh_llm/models.py
+++ b/src/gh_llm/models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 

--- a/src/gh_llm/pager.py
+++ b/src/gh_llm/pager.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from typing import TYPE_CHECKING
 

--- a/src/gh_llm/pr_body.py
+++ b/src/gh_llm/pr_body.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 import unicodedata
 from dataclasses import dataclass

--- a/src/gh_llm/render.py
+++ b/src/gh_llm/render.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import re
 import shlex

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import base64
 import json

--- a/tests/test_command_options.py
+++ b/tests/test_command_options.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 
 import pytest

--- a/tests/test_extension_entrypoint.py
+++ b/tests/test_extension_entrypoint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import stat
 import subprocess

--- a/tests/test_pr_body.py
+++ b/tests/test_pr_body.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gh_llm.pr_body import (
     build_pull_request_body_scaffold,
     extract_markdown_section_titles,


### PR DESCRIPTION
## Summary

Remove `from __future__ import annotations` across the package and tests now that `gh-llm` requires Python 3.14.

Also remove the Ruff flake8-future-annotations selection and isort `required-imports` configuration so tooling no longer auto-adds the PEP 563 import.

## Validation

- `uv run ruff format --check --diff .`
- `uv run ty check --error-on-warning src/gh_llm tests`
- `uv run ruff check .`
- `uv run pytest`